### PR TITLE
Fix Kaco Current Power and Energy Today sensors after 2023.02

### DIFF
--- a/custom_components/kaco/__init__.py
+++ b/custom_components/kaco/__init__.py
@@ -64,9 +64,7 @@ def exc():
     _LOGGER.error("============= KACO Integration Error ================\n\n")
 
 
-async def get_coordinator(
-    hass: HomeAssistant, config: Dict
-) -> update_coordinator.DataUpdateCoordinator:
+async def get_coordinator(hass: HomeAssistant, config: Dict) -> update_coordinator.DataUpdateCoordinator:
     ip = config.get(CONF_KACO_URL)
     kwhInterval = float(config.get(CONF_KWH_INTERVAL))
     if kwhInterval == None:
@@ -74,7 +72,7 @@ async def get_coordinator(
     interval = float(config.get(CONF_INTERVAL))
     if interval == None:
         interval = float(DEFAULT_INTERVAL)
-    _LOGGER.debug("initialize the data coordinator for IP %s", ip)
+    _LOGGER.debug("initialize the date coordinator for IP %s", ip)
     if DOMAIN in hass.data:
         if ip in hass.data[DOMAIN]:
             if "coordinator" in hass.data[DOMAIN][ip]:
@@ -104,9 +102,7 @@ async def get_coordinator(
             now = datetime.datetime.now(get_localzone()).replace(microsecond=0)
 
             if not "last_kWh_Update" in values["extra"]:
-                values["extra"]["last_kWh_Update"] = now - timedelta(
-                    seconds=kwhInterval
-                )
+                values["extra"]["last_kWh_Update"] = now - timedelta(seconds=kwhInterval)
 
             d = await hass.async_add_executor_job(
                 partial(requests.get, url_rt, timeout=2)
@@ -134,22 +130,15 @@ async def get_coordinator(
             values["extra"]["temp"] = float(ds[12]) / 100
             values["extra"]["status"] = t[int(ds[13])]
             values["extra"]["status_code"] = int(ds[13])
-            values[MEAS_CURRENT_POWER.valueKey] = round(
-                float(ds[11]) / (65535 / 100000)
-            )
+            values[MEAS_CURRENT_POWER.valueKey] = round(float(ds[11]) / (65535 / 100000))
 
             if values[MEAS_CURRENT_POWER.valueKey] > values["extra"]["max_power"]:
                 values["extra"]["max_power"] = values[MEAS_CURRENT_POWER.valueKey]
                 hass.data[DOMAIN][ip]["max_power"] = values[MEAS_CURRENT_POWER.valueKey]
 
-            if (
-                now
-                >= values["extra"]["last_kWh_Update"]
-                + datetime.timedelta(seconds=kwhInterval)
-                or not MEAS_ENERGY_TODAY.valueKey in values
-            ):
+            if now >= values["extra"]["last_kWh_Update"] + datetime.timedelta(seconds=kwhInterval) or not MEAS_ENERGY_TODAY.valueKey in values:
                 d = await hass.async_add_executor_job(
-                    partial(requests.get, url_today, timeout=10)
+                    partial(requests.get, url_today, timeout=30)
                 )
                 if d.status_code == 200:
                     # New daily values are only avilable after self-test in the morning.
@@ -160,14 +149,10 @@ async def get_coordinator(
                         dss = ds.split(";")
                         if len(dss) > 4:
                             values[MEAS_ENERGY_TODAY.valueKey] = float(dss[4])
-                            hass.data[DOMAIN][ip][MEAS_ENERGY_TODAY.valueKey] = values[
-                                MEAS_ENERGY_TODAY.valueKey
-                            ]
-                            # TODO Lokal speichern da UID
+                            hass.data[DOMAIN][ip][MEAS_ENERGY_TODAY.valueKey] = values[MEAS_ENERGY_TODAY.valueKey]
+                            #TODO Lokal speichern da UID
                             values["extra"]["serialno"] = dss[1]
-                            hass.data[DOMAIN][ip]["serialno"] = values["extra"][
-                                "serialno"
-                            ]
+                            hass.data[DOMAIN][ip]["serialno"] = values["extra"]["serialno"]
                             values["extra"]["model"] = dss[0]
                             values["extra"]["last_kWh_Update"] = now
         except requests.exceptions.Timeout as to:

--- a/custom_components/kaco/__init__.py
+++ b/custom_components/kaco/__init__.py
@@ -72,7 +72,7 @@ async def get_coordinator(hass: HomeAssistant, config: Dict) -> update_coordinat
     interval = float(config.get(CONF_INTERVAL))
     if interval == None:
         interval = float(DEFAULT_INTERVAL)
-    _LOGGER.debug("initialize the date coordinator for IP %s", ip)
+    _LOGGER.debug("initialize the data coordinator for IP %s", ip)
     if DOMAIN in hass.data:
         if ip in hass.data[DOMAIN]:
             if "coordinator" in hass.data[DOMAIN][ip]:

--- a/custom_components/kaco/const.py
+++ b/custom_components/kaco/const.py
@@ -7,7 +7,12 @@ import traceback
 import logging
 import datetime
 from collections import OrderedDict
-
+from homeassistant.const import (
+    ENERGY_KILO_WATT_HOUR,
+    ELECTRIC_CURRENT_AMPERE,
+    ELECTRIC_POTENTIAL_VOLT,
+    POWER_WATT
+)
 from voluptuous.validators import Coerce
 
 
@@ -246,18 +251,18 @@ class MeasurementObj:
 
 
 # measurements
-MEAS_CURRENT_POWER = MeasurementObj("currentPower", "W", isMandatory=True)
-MEAS_ENERGY_TODAY = MeasurementObj("energyToday", "kWh", isMandatory=True)
-MEAS_GEN_VOLT1 = MeasurementObj("generatorVoltage1", "V", CONF_GENERATOR_VOLTAGE)
-MEAS_GEN_VOLT2 = MeasurementObj("generatorVoltage2", "V", CONF_GENERATOR_VOLTAGE)
-MEAS_GEN_CURR1 = MeasurementObj("generatorCurrent1", "A", CONF_GENERATOR_CURRENT)
-MEAS_GEN_CURR2 = MeasurementObj("generatorCurrent2", "A", CONF_GENERATOR_CURRENT)
-MEAS_GRID_VOLT1 = MeasurementObj("gridVoltage1", "V", CONF_GRID_VOLTAGE)
-MEAS_GRID_VOLT2 = MeasurementObj("gridVoltage2", "V", CONF_GRID_VOLTAGE)
-MEAS_GRID_VOLT3 = MeasurementObj("gridVoltage3", "V", CONF_GRID_VOLTAGE)
-MEAS_GRID_CURR1 = MeasurementObj("gridCurrent1", "A", CONF_GRID_CURRENT)
-MEAS_GRID_CURR2 = MeasurementObj("gridCurrent2", "A", CONF_GRID_CURRENT)
-MEAS_GRID_CURR3 = MeasurementObj("gridCurrent3", "A", CONF_GRID_CURRENT)
+MEAS_CURRENT_POWER = MeasurementObj("currentPower", POWER_WATT, isMandatory=True)
+MEAS_ENERGY_TODAY = MeasurementObj("energyToday", ENERGY_KILO_WATT_HOUR, isMandatory=True)
+MEAS_GEN_VOLT1 = MeasurementObj("generatorVoltage1", ELECTRIC_POTENTIAL_VOLT, CONF_GENERATOR_VOLTAGE)
+MEAS_GEN_VOLT2 = MeasurementObj("generatorVoltage2", ELECTRIC_POTENTIAL_VOLT, CONF_GENERATOR_VOLTAGE)
+MEAS_GEN_CURR1 = MeasurementObj("generatorCurrent1", ELECTRIC_CURRENT_AMPERE, CONF_GENERATOR_CURRENT)
+MEAS_GEN_CURR2 = MeasurementObj("generatorCurrent2", ELECTRIC_CURRENT_AMPERE, CONF_GENERATOR_CURRENT)
+MEAS_GRID_VOLT1 = MeasurementObj("gridVoltage1", ELECTRIC_POTENTIAL_VOLT, CONF_GRID_VOLTAGE)
+MEAS_GRID_VOLT2 = MeasurementObj("gridVoltage2", ELECTRIC_POTENTIAL_VOLT, CONF_GRID_VOLTAGE)
+MEAS_GRID_VOLT3 = MeasurementObj("gridVoltage3", ELECTRIC_POTENTIAL_VOLT, CONF_GRID_VOLTAGE)
+MEAS_GRID_CURR1 = MeasurementObj("gridCurrent1", ELECTRIC_CURRENT_AMPERE, CONF_GRID_CURRENT)
+MEAS_GRID_CURR2 = MeasurementObj("gridCurrent2", ELECTRIC_CURRENT_AMPERE, CONF_GRID_CURRENT)
+MEAS_GRID_CURR3 = MeasurementObj("gridCurrent3", ELECTRIC_CURRENT_AMPERE, CONF_GRID_CURRENT)
 
 MEAS_VALUES = [
     MEAS_CURRENT_POWER,

--- a/custom_components/kaco/sensor.py
+++ b/custom_components/kaco/sensor.py
@@ -12,8 +12,11 @@ from homeassistant.helpers import update_coordinator
 from homeassistant.helpers.entity import Entity, async_generate_entity_id
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.components.sensor import ENTITY_ID_FORMAT, SensorEntity
-from homeassistant.const import CONF_NAME
-
+from homeassistant.const import (
+    CONF_NAME,
+    ENERGY_KILO_WATT_HOUR,
+    DEVICE_CLASS_ENERGY
+)
 from tzlocal import get_localzone
 from functools import partial
 import requests
@@ -129,8 +132,8 @@ class kaco_sensor(CoordinatorEntity, SensorEntity):
 
     @property
     def device_class(self):
-        return "energy" if self._unit == "kWh" else None
+        return DEVICE_CLASS_ENERGY if self._unit == ENERGY_KILO_WATT_HOUR else None
 
     @property
     def state_class(self):
-        return "total_increasing" if self._unit == "kWh" else None
+        return "total_increasing" if self._unit == ENERGY_KILO_WATT_HOUR else None

--- a/custom_components/kaco/sensor.py
+++ b/custom_components/kaco/sensor.py
@@ -126,6 +126,11 @@ class kaco_sensor(CoordinatorEntity, SensorEntity):
         return self._unit
 
     @property
+    def native_unit_of_measurement(self):
+        """Return the unit the value is expressed in natively."""
+        return self._unit
+
+    @property
     def native_value(self):
         """Return the state of the sensor."""
         return self.coordinator.data.get(self._valueKey)


### PR DESCRIPTION
After home-assistant/core/pull/85694 that was included in the 2023.02 update the Kaco integration broke partially, no longer showing `Current Power` and `Energy Today` sensors.

With this code locally it works for me again
![Screenshot 2023-02-03 at 12 05 40](https://user-images.githubusercontent.com/19285728/216588269-31f58932-e204-4a0d-aa95-03ed4816573e.png)
(No it's not a sunny day here)

Fixes KoljaWindeler/kaco/issues/10

This also includes some other cleanups that I was already using locally and which branch I extended here.